### PR TITLE
make message for invalid activation key more precise

### DIFF
--- a/registration/templates/activate.html
+++ b/registration/templates/activate.html
@@ -2,13 +2,13 @@
 {% load i18n %}
 {% block title %}{% if account %} Activation complete {% else %}Activation problem{% endif %}{% endblock %}
 {% block content %}
-{% url 'auth_login' as auth_login_url %}
-{% if account %}
-{% blocktrans %}
-Thanks {{ account }}, activation complete!
-You may now <a href='{{ auth_login_url}}'>login</a> using the username and password you set at registration.
-{% endblocktrans %}
-{% else %}
-{% blocktrans trimmed %}Oops &ndash; it seems that your activation key is invalid. Please check the url again.{% endblocktrans %}
-{% endif %}
+    {% url 'auth_login' as auth_login_url %}
+    {% if account %}
+        {% blocktrans %}
+            Thanks {{ account }}, activation complete!
+            You may now <a href='{{ auth_login_url}}'>login</a> using the username and password you set at registration.
+        {% endblocktrans %}
+    {% else %}
+        {% blocktrans %}Oops &ndash; Either you activated your account already, or the activation key is invalid or has expired.{% endblocktrans %}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
An easy one for my first PR. 

see: https://trello.com/c/7OzeuDDK/23-visiting-activation-link-a-second-time-gives-an-error-if-user-is-already-activated