### PR TITLE
Enhanced internationalization

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-13 19:22+0200\n"
+"POT-Creation-Date: 2015-09-14 00:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: account/templates/user_account_edit.html:14
+msgid "Save"
+msgstr "Speichern"
+
+#: account/templates/user_detail.html:14 registration/forms.py:34
+msgid "Username"
+msgstr "Benutzername"
+
+#: account/templates/user_detail.html:15
+msgid "First name"
+msgstr "Vorname"
+
+#: account/templates/user_detail.html:16
+msgid "Last name"
+msgstr "Nachname"
+
+#: account/templates/user_detail.html:17 registration/forms.py:37
+msgid "Email"
+msgstr "E-Mail Adresse"
+
+#: account/templates/user_detail.html:19
+msgid "Edit Account"
+msgstr "Account bearbeiten"
 
 #: notifications/models.py:13
 msgid "title"
@@ -38,17 +62,11 @@ msgstr "Benutzer aktivieren"
 msgid "Re-send activation emails"
 msgstr "Aktivierungsmail erneut versenden"
 
-#: registration/forms.py:34
-msgid "Username"
-msgstr "Benutzername"
-
 #: registration/forms.py:35
 msgid "This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr "Der Wert darf nur Buchstaben, Zahlen und die Zeichen @, ., +, - und _ enthalten"
-
-#: registration/forms.py:37
-msgid "E-mail"
-msgstr "E-Mail Adresse"
+msgstr ""
+"Der Wert darf nur Buchstaben, Zahlen und die Zeichen @, ., +, - und _ "
+"enthalten"
 
 #: registration/forms.py:39
 msgid "Password"
@@ -64,7 +82,9 @@ msgstr "Es gibt bereits einen Benutzer mit diesem Benutzernamen."
 
 #: registration/forms.py:58
 msgid "A user with that email already exists. Please login instead."
-msgstr "Die Emailadresse ist bereits bekannt. Bitte logge Dich ein mit Deinem Benutzername und Password."
+msgstr ""
+"Die Emailadresse ist bereits bekannt. Bitte logge Dich ein mit Deinem "
+"Benutzername und Password."
 
 #: registration/forms.py:82
 msgid "I have read and agree to the Terms of Service"
@@ -75,12 +95,20 @@ msgid "You must agree to the terms to register"
 msgstr "Sie müssen den Nutzungsbedingungen zustimmen"
 
 #: registration/forms.py:99
-msgid "This email address is already in use. Please supply a different email address."
-msgstr "Diese E-Mail Adresse ist bereits registriert. Bitte verwenden Sie eine andere E-Mail Adresse"
+msgid ""
+"This email address is already in use. Please supply a different email "
+"address."
+msgstr ""
+"Diese E-Mail Adresse ist bereits registriert. Bitte verwenden Sie eine "
+"andere E-Mail Adresse"
 
 #: registration/forms.py:124
-msgid "Registration using free email addresses is prohibited. Please supply a different email address."
+msgid ""
+"Registration using free email addresses is prohibited. Please supply a "
+"different email address."
 msgstr ""
+"Die Registrierung mit einer E-Mail-Adresses dieses Anbieters ist leider "
+"verboten. Bitte verwende eine andere E-Mail-Adresse."
 
 #: registration/models.py:219
 msgid "user"
@@ -94,13 +122,24 @@ msgstr "Aktivierungsschlüssel"
 #, python-format
 msgid ""
 "\n"
-"Thanks %(account)s, activation complete!\n"
-"You may now <a href='%(auth_login_url)s'>login</a> using the username and password you set at registration.\n"
+"            Thanks %(account)s, activation complete!\n"
+"            You may now <a href='%(auth_login_url)s'>login</a> using the "
+"username and password you set at registration.\n"
+"        "
 msgstr ""
+"\n"
+"            Danke %(account)s, die Aktivierung ist abgeschlossen!\n"
+"Du kannst dich jetzt mit deinem Benutzernamen und Passwort, welche du bei "
+"der Registrierung gewählt hast <a href='%(auth_login_url)s'>einloggen</a>.\n"
+"        "
 
 #: registration/templates/activate.html:12
-msgid "Oops &ndash; it seems that your activation key is invalid. Please check the url again."
+msgid ""
+"Oops &ndash; Either you activated your account already, or the activation "
+"key is invalid or has expired."
 msgstr ""
+"Uuppss &ndash; Entweder dein Account wurde bereits aktiviert oder der "
+"Aktivierungschlüssel ist ungültig oder abgelaufen."
 
 #: registration/templates/login.html:15
 msgid "Your username and password didn't match. Please try again."
@@ -124,7 +163,9 @@ msgstr "Hilfebereich"
 
 #: scheduler/models.py:20
 msgid "helptype_text"
-msgstr "Jeder Hilfebereich hat so viele Planelemente wie es Arbeitsschichten geben soll. Dies ist EINE Arbeitsschicht für einen bestimmten Tag"
+msgstr ""
+"Jeder Hilfebereich hat so viele Planelemente wie es Arbeitsschichten geben "
+"soll. Dies ist EINE Arbeitsschicht für einen bestimmten Tag"
 
 #: scheduler/models.py:21 scheduler/models.py:125
 msgid "location"
@@ -162,16 +203,20 @@ msgstr "Zeitspannen"
 msgid "locations"
 msgstr "Orte"
 
-#: scheduler/views.py:96
+#: scheduler/views.py:79
 msgid "The submitted data was invalid."
 msgstr "Die eingegebenen Daten sind ungültig."
 
-#: scheduler/views.py:107
+#: scheduler/views.py:90
 #, python-brace-format
-msgid "We can't add you to this shift because you've already agreed to other shifts at the same time: {conflicts}"
-msgstr "Sie können der Schicht nicht beitreten, da Sie bereits an anderen mit überschneidenden Zeiten teilnehmen: {conflicts}"
+msgid ""
+"We can't add you to this shift because you've already agreed to other shifts "
+"at the same time: {conflicts}"
+msgstr ""
+"Sie können der Schicht nicht beitreten, da Sie bereits an anderen mit "
+"überschneidenden Zeiten teilnehmen: {conflicts}"
 
-#: scheduler/views.py:110
+#: scheduler/views.py:93
 msgid "You were successfully added to this shift."
 msgstr "Sie haben sich erfolgreich für die Schicht angemeldet."
 
@@ -195,11 +240,11 @@ msgstr "Organisation"
 msgid "email"
 msgstr "E-Mail"
 
-#: volunteer_planner/settings/base.py:128
+#: volunteer_planner/settings/base.py:130
 msgid "German"
 msgstr "Deutsch"
 
-#: volunteer_planner/settings/base.py:129
+#: volunteer_planner/settings/base.py:131
 msgid "English"
 msgstr "Englisch"
 
@@ -209,8 +254,12 @@ msgstr ""
 
 #: volunteer_planner/templates/registration/password_reset_complete.html:4
 #, python-format
-msgid "Your password has been reset! You may now <a href=\"%(login_url)s\">log in</a>."
-msgstr "Ihr Passwort wurde geändert. Sie können sich jetzt <a href=\"%(login_url)s\">erneut anmelden</a>."
+msgid ""
+"Your password has been reset! You may now <a href=\"%(login_url)s\">log in</"
+"a>."
+msgstr ""
+"Ihr Passwort wurde geändert. Sie können sich jetzt <a href=\"%(login_url)s"
+"\">erneut anmelden</a>."
 
 #: volunteer_planner/templates/registration/password_reset_done.html:6
 msgid ""
@@ -222,10 +271,12 @@ msgstr ""
 #, python-format
 msgid ""
 "You are receiving this email because you (or someone pretending to be you)\n"
-"requested that your password be reset on the %(domain)s site.  If you do not\n"
+"requested that your password be reset on the %(domain)s site.  If you do "
+"not\n"
 "wish to reset your password, please ignore this message.\n"
 "\n"
-"To reset your password, please click the following link, or copy and paste it\n"
+"To reset your password, please click the following link, or copy and paste "
+"it\n"
 "into your web browser:"
 msgstr ""
 
@@ -242,3 +293,6 @@ msgstr ""
 #: volunteer_planner/templates/registration/password_reset_form.html:16
 msgid "Reset password"
 msgstr "Passwort zurücksetzen"
+
+#~ msgid "E-mail"
+#~ msgstr "E-Mail Adresse"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-14 00:11+0200\n"
+"POT-Creation-Date: 2015-09-14 10:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -64,9 +64,7 @@ msgstr "Aktivierungsmail erneut versenden"
 
 #: registration/forms.py:35
 msgid "This value may contain only letters, numbers and @/./+/-/_ characters."
-msgstr ""
-"Der Wert darf nur Buchstaben, Zahlen und die Zeichen @, ., +, - und _ "
-"enthalten"
+msgstr "Der Wert darf nur Buchstaben, Zahlen und die Zeichen @, ., +, - und _ enthalten"
 
 #: registration/forms.py:39
 msgid "Password"
@@ -82,9 +80,7 @@ msgstr "Es gibt bereits einen Benutzer mit diesem Benutzernamen."
 
 #: registration/forms.py:58
 msgid "A user with that email already exists. Please login instead."
-msgstr ""
-"Die Emailadresse ist bereits bekannt. Bitte logge Dich ein mit Deinem "
-"Benutzername und Password."
+msgstr "Die Emailadresse ist bereits bekannt. Bitte logge Dich ein mit Deinem Benutzername und Password."
 
 #: registration/forms.py:82
 msgid "I have read and agree to the Terms of Service"
@@ -95,20 +91,12 @@ msgid "You must agree to the terms to register"
 msgstr "Sie müssen den Nutzungsbedingungen zustimmen"
 
 #: registration/forms.py:99
-msgid ""
-"This email address is already in use. Please supply a different email "
-"address."
-msgstr ""
-"Diese E-Mail Adresse ist bereits registriert. Bitte verwenden Sie eine "
-"andere E-Mail Adresse"
+msgid "This email address is already in use. Please supply a different email address."
+msgstr "Diese E-Mail Adresse ist bereits registriert. Bitte verwenden Sie eine andere E-Mail Adresse"
 
 #: registration/forms.py:124
-msgid ""
-"Registration using free email addresses is prohibited. Please supply a "
-"different email address."
-msgstr ""
-"Die Registrierung mit einer E-Mail-Adresses dieses Anbieters ist leider "
-"verboten. Bitte verwende eine andere E-Mail-Adresse."
+msgid "Registration using free email addresses is prohibited. Please supply a different email address."
+msgstr "Die Registrierung mit einer E-Mail-Adresses dieses Anbieters ist leider verboten. Bitte verwende eine andere E-Mail-Adresse."
 
 #: registration/models.py:219
 msgid "user"
@@ -120,26 +108,12 @@ msgstr "Aktivierungsschlüssel"
 
 #: registration/templates/activate.html:7
 #, python-format
-msgid ""
-"\n"
-"            Thanks %(account)s, activation complete!\n"
-"            You may now <a href='%(auth_login_url)s'>login</a> using the "
-"username and password you set at registration.\n"
-"        "
-msgstr ""
-"\n"
-"            Danke %(account)s, die Aktivierung ist abgeschlossen!\n"
-"Du kannst dich jetzt mit deinem Benutzernamen und Passwort, welche du bei "
-"der Registrierung gewählt hast <a href='%(auth_login_url)s'>einloggen</a>.\n"
-"        "
+msgid "Thanks %(account)s, activation complete! You may now <a href='%(auth_login_url)s'>login</a> using the username and password you set at registration."
+msgstr "Danke %(account)s, die Aktivierung ist abgeschlossen! Du kannst dich jetzt mit deinem Benutzernamen und Passwort, welche du bei der Registrierung gewählt hast <a href='%(auth_login_url)s'>einloggen</a>."
 
 #: registration/templates/activate.html:12
-msgid ""
-"Oops &ndash; Either you activated your account already, or the activation "
-"key is invalid or has expired."
-msgstr ""
-"Uuppss &ndash; Entweder dein Account wurde bereits aktiviert oder der "
-"Aktivierungschlüssel ist ungültig oder abgelaufen."
+msgid "Oops &ndash; Either you activated your account already, or the activation key is invalid or has expired."
+msgstr "Uuppss &ndash; Entweder dein Account wurde bereits aktiviert oder der Aktivierungschlüssel ist ungültig oder abgelaufen."
 
 #: registration/templates/login.html:15
 msgid "Your username and password didn't match. Please try again."
@@ -163,9 +137,7 @@ msgstr "Hilfebereich"
 
 #: scheduler/models.py:20
 msgid "helptype_text"
-msgstr ""
-"Jeder Hilfebereich hat so viele Planelemente wie es Arbeitsschichten geben "
-"soll. Dies ist EINE Arbeitsschicht für einen bestimmten Tag"
+msgstr "Jeder Hilfebereich hat so viele Planelemente wie es Arbeitsschichten geben soll. Dies ist EINE Arbeitsschicht für einen bestimmten Tag"
 
 #: scheduler/models.py:21 scheduler/models.py:125
 msgid "location"
@@ -209,12 +181,8 @@ msgstr "Die eingegebenen Daten sind ungültig."
 
 #: scheduler/views.py:90
 #, python-brace-format
-msgid ""
-"We can't add you to this shift because you've already agreed to other shifts "
-"at the same time: {conflicts}"
-msgstr ""
-"Sie können der Schicht nicht beitreten, da Sie bereits an anderen mit "
-"überschneidenden Zeiten teilnehmen: {conflicts}"
+msgid "We can't add you to this shift because you've already agreed to other shifts at the same time: {conflicts}"
+msgstr "Sie können der Schicht nicht beitreten, da Sie bereits an anderen mit überschneidenden Zeiten teilnehmen: {conflicts}"
 
 #: scheduler/views.py:93
 msgid "You were successfully added to this shift."
@@ -254,12 +222,8 @@ msgstr ""
 
 #: volunteer_planner/templates/registration/password_reset_complete.html:4
 #, python-format
-msgid ""
-"Your password has been reset! You may now <a href=\"%(login_url)s\">log in</"
-"a>."
-msgstr ""
-"Ihr Passwort wurde geändert. Sie können sich jetzt <a href=\"%(login_url)s"
-"\">erneut anmelden</a>."
+msgid "Your password has been reset! You may now <a href=\"%(login_url)s\">log in</a>."
+msgstr "Ihr Passwort wurde geändert. Sie können sich jetzt <a href=\"%(login_url)s\">erneut anmelden</a>."
 
 #: volunteer_planner/templates/registration/password_reset_done.html:6
 msgid ""
@@ -271,12 +235,10 @@ msgstr ""
 #, python-format
 msgid ""
 "You are receiving this email because you (or someone pretending to be you)\n"
-"requested that your password be reset on the %(domain)s site.  If you do "
-"not\n"
+"requested that your password be reset on the %(domain)s site.  If you do not\n"
 "wish to reset your password, please ignore this message.\n"
 "\n"
-"To reset your password, please click the following link, or copy and paste "
-"it\n"
+"To reset your password, please click the following link, or copy and paste it\n"
 "into your web browser:"
 msgstr ""
 
@@ -293,6 +255,3 @@ msgstr ""
 #: volunteer_planner/templates/registration/password_reset_form.html:16
 msgid "Reset password"
 msgstr "Passwort zurücksetzen"
-
-#~ msgid "E-mail"
-#~ msgstr "E-Mail Adresse"

--- a/registration/forms.py
+++ b/registration/forms.py
@@ -34,7 +34,7 @@ class RegistrationForm(forms.Form):
                                 label=_("Username"),
                                 error_messages={'invalid': _("This value may contain only letters, numbers and "
                                                              "@/./+/-/_ characters.")})
-    email = forms.EmailField(label=_("E-mail"))
+    email = forms.EmailField(label=_("Email"))
     password1 = forms.CharField(widget=forms.PasswordInput,
                                 label=_("Password"))
     password2 = forms.CharField(widget=forms.PasswordInput,

--- a/registration/templates/activate.html
+++ b/registration/templates/activate.html
@@ -4,7 +4,7 @@
 {% block content %}
     {% url 'auth_login' as auth_login_url %}
     {% if account %}
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             Thanks {{ account }}, activation complete!
             You may now <a href='{{ auth_login_url}}'>login</a> using the username and password you set at registration.
         {% endblocktrans %}


### PR DESCRIPTION
Fixed localization key in forms to match already used value.
Added some translations for account page, registration, activation.

Registration form, scheduler model, scheduler view and password reset
page got msgid's reformated by makemessages.
We should stick to wrapped notation, as otherwise makemessages will
enforce us to manually correct msgid's before committing.