### PR TITLE
Activated localization

### DIFF
--- a/volunteer_planner/settings/base.py
+++ b/volunteer_planner/settings/base.py
@@ -124,8 +124,8 @@ LOGIN_URL = '/auth/login/'
 
 TIME_ZONE = 'Europe/Berlin'
 
-LANGUAGE_CODE = 'de'
-
+LANGUAGE_CODE = 'de-de'
+USE_L10N = True
 LANGUAGES = (
     ('de', _('German')),
     ('en', _('English')),


### PR DESCRIPTION
Without USE_L10N localization is not done. This makes number formatting
result, like from 'intcomma' in home.html, a little less intuitive.
LANGUAGE_CODE, which is fall back in case no user specific language can
be determined or it's not supported, set to official identifier.