### PR TITLE
Add admin link

### DIFF
--- a/scheduler/templates/navbar.html
+++ b/scheduler/templates/navbar.html
@@ -23,6 +23,9 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">eingeloggt als {{ user.username }}  <span class="caret"></span></a>
           <ul class="dropdown-menu">
             <li><a href="{% url 'account_detail' %}">Account <span aria-hidden="true"></span></a></li>
+            {% if user.is_staff or user.is_superuser %}
+                <li><a href="{% url 'admin:index' %}">Admin <span aria-hidden="true"></span></a></li>
+            {% endif %}
             <li><a href="{% url 'auth_logout' %}">Logout <span aria-hidden="true" class="glyphicon glyphicon-off"></span></a></li>
           </ul>
         </li>


### PR DESCRIPTION
Staff and Superuser get a link in navbar, close to account, to access
admin area easier after logging in.