### PR TITLE
Format and extend google anayltics tracking

### DIFF
--- a/google_tools/templates/google_headers.html
+++ b/google_tools/templates/google_headers.html
@@ -1,19 +1,32 @@
-{% if google_tools %}{% if google_tools.site_verification %}
-<meta name="google-site-verification" content="{{ google_tools.site_verification }}"/>
-{% endif %}{% if google_tools.analytics %}
-<script>
-    (function (i, s, o, g, r, a, m) {
-        i['GoogleAnalyticsObject'] = r;
-        i[r] = i[r] || function () {
-                    (i[r].q = i[r].q || []).push(arguments)
-                }, i[r].l = 1 * new Date();
-        a = s.createElement(o),
-                m = s.getElementsByTagName(o)[0];
-        a.async = 1;
-        a.src = g;
-        m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+{% if google_tools %}
+    {% if google_tools.site_verification %}
+        <meta name="google-site-verification" content="{{ google_tools.site_verification }}"/>
+    {% endif %}
+    {% if google_tools.analytics %}
+        <script>
+            var disableStr = 'ga-disable-{{ google_tools.analytics.tracking_id }}';
+            if (document.cookie.indexOf(disableStr + '=true') > -1) {
+                window[disableStr] = true;
+            }
+            function gaOptout() {
+                document.cookie = disableStr + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
+                window[disableStr] = true;
+            }
+            (function (i, s, o, g, r, a, m) {
+                i['GoogleAnalyticsObject'] = r;
+                i[r] = i[r] || function () {
+                            (i[r].q = i[r].q || []).push(arguments)
+                        }, i[r].l = 1 * new Date();
+                a = s.createElement(o),
+                        m = s.getElementsByTagName(o)[0];
+                a.async = 1;
+                a.src = g;
+                m.parentNode.insertBefore(a, m)
+            })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
-    ga('create', '{{ google_tools.analytics.tracking_id }}', '{{ google_tools.analytics.domain|default:"auto" }}');
-    ga('send', 'pageview');
-</script>{% endif %}{% endif %}
+            ga('create', '{{ google_tools.analytics.tracking_id }}', '{{ google_tools.analytics.domain|default:"auto" }}');
+            ga('set', 'anonymizeIp', true);
+            ga('send', 'pageview');
+        </script>
+    {% endif %}
+{% endif %}


### PR DESCRIPTION
- fix indenting with all the if-blocks
- add privacy feature to opt out of GA by cookie
- add privacy feature to anonymize IPs
Both are needed in Germany. The gaOptout() link should be part of the
privacy policy once there is one.

For details, read https://www.google.com/intl/en/analytics/learn/privacy.html chapter
„Use of IP address“, which leads to https://support.google.com/analytics/answer/2763052?vid=1-635782626182547029-1742600112

And https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced chapter „User Opt-out“