### PR TITLE
Rework WorkDone error handling

### DIFF
--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -108,6 +108,12 @@ class Location(models.Model):
 
 
 class WorkDone(models.Model):
+    """
+    A SQL view is used to calculate total volunteer hours. This unmanaged model is used to
+    let us access that data via Django.
+
+    Note that this won't work with a local SQLite backend.
+    """
     id = models.IntegerField(primary_key=True)
     hours = models.IntegerField(name=u'hours', verbose_name=_('working hours'))
 

--- a/scheduler/views.py
+++ b/scheduler/views.py
@@ -6,7 +6,7 @@ import logging
 
 from django.core.urlresolvers import reverse
 from django.contrib import messages
-from django.db import ProgrammingError
+from django.db import ProgrammingError, OperationalError
 from django.http.response import HttpResponseRedirect, JsonResponse
 from django.shortcuts import render, get_object_or_404
 from django.db.models import Count
@@ -24,6 +24,9 @@ from .forms import RegisterForNeedForm
 from volunteer_planner.utils import LoginRequiredMixin
 
 
+logger = logging.getLogger(__name__)
+
+
 class HomeView(TemplateView):
     template_name = "home.html"
 
@@ -37,16 +40,16 @@ class HomeView(TemplateView):
         context = super(HomeView, self).get_context_data(**kwargs)
         context['locations'] = Location.objects.all()
         context['notifications'] = Notification.objects.all()
-        log = logging.getLogger(__name__)
         try:
-            context['working_hours'] = WorkDone.objects.get(id=1)
-            log.debug(u'Working hours: %s', context['working_hours'])
-        except WorkDone.DoesNotExist:
-            context['working_hours'] = ""
-        # In case the unmanaged model ain't created correctly there's not point in spitting out errors.
-        # This information is auxiliarry and if we don't have it yet, don't harras the user.
-        except ProgrammingError:
-            context['working_hours'] = ""
+            work_done = WorkDone.objects.get(pk=1)
+        except (WorkDone.DoesNotExist, ProgrammingError, OperationalError):
+            # In case the unmanaged model isn't created correctly or a developer is e.g. using
+            # SQLite instead of MySQL, we don't want to fail loud and hard. The work done is
+            # auxiliary information and we just log a warning.
+            logger.warning(u"Work done view couldn't be accessed. Is the SQL view created?")
+            work_done = ""
+        finally:
+            context['working_hours'] = work_done
         return context
 
 


### PR DESCRIPTION
I started work on Volunteer Planner and was met with a OperationalError:
no such table: work_done message. So I looked into what's happening.

This commit:
* Adds OperationalError to the list of ignored errors
* Removes the debug statement; should be easy enough to access
  with Django Debug Toolbar
* Reworks to a more pythonic exception handling