### PR TITLE
Cleaner layout for helpdesk template

### DIFF
--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -96,15 +96,23 @@ class Location(models.Model):
     def __unicode__(self):
         return u'{}'.format(self.name)
 
-    def get_dates_of_needs(self):
-        needs_dates = []
-        for i in self.need_set.all().filter(ending_time__gt=datetime.datetime.now()) \
-                .order_by('ending_time'):
-            date_name = i.starting_time.strftime("%A, %d.%m.%Y")
-            locale.setlocale(locale.LC_ALL, 'de_DE.UTF-8')
-            if date_name not in needs_dates:
-                needs_dates.append(i.starting_time.strftime("%A, %d.%m.%Y"))
-        return needs_dates
+    def get_days_with_needs(self):
+        """
+        Returns a list of tuples, representing days that this location has
+        needs. The tuple contains a datetime object, and a date formatted
+        in German format.
+        """
+        dates = self.need_set.filter(ending_time__gt=datetime.datetime.now()
+            ).order_by('ending_time').values_list('starting_time', flat=True)
+        dates_and_date_strings = []
+        seen_date_strings = []
+        locale.setlocale(locale.LC_ALL, 'de_DE.UTF-8')  # FIXME
+        for date in dates:
+            date_string = date.strftime("%A, %d.%m.%Y")
+            if date_string not in seen_date_strings:
+                seen_date_strings.append(date_string)
+                dates_and_date_strings.append((date, date_string))
+        return dates_and_date_strings
 
 
 class WorkDone(models.Model):

--- a/scheduler/templates/helpdesk.html
+++ b/scheduler/templates/helpdesk.html
@@ -13,24 +13,26 @@
     {% for location in locations %}
         <div class="row">
             <div class="col-md-5">
-                <h3 style="padding:0; margin:0;">{{ location }} </h3>
+                <h3>{{ location }}</h3>
                 <p>
                     {{ location.street }}<br>
                     {{ location.postal_code }} {{ location.city }}
                 </p>
                 <p>
-                    <span aria-hidden="true" class="glyphicon glyphicon-flag"></span>{{  location.additional_info|safe }}
+                    {{  location.additional_info|safe }}
                 </p>
             </div>
             <div class="col-md-4">
-                <p>
-                    {% for date_single in location.get_dates_of_needs %}
-                        <span aria-hidden="true" class="glyphicon glyphicon-chevron-right"></span>
-                        <a href="{% url 'planner_by_location' pk=location.pk year=date_single|slice:'-4:' month=date_single|slice:'-7:-5' day=date_single|slice:'-10:-8' %}">
-                            {{ date_single }} [ansehen]
-                        </a>
+                <ul class="list-unstyled">
+                    {% for date, date_name in location.get_days_with_needs %}
+                        <li>
+                            <span aria-hidden="true" class="glyphicon glyphicon-chevron-right"></span>
+                            <a href="{% url 'planner_by_location' pk=location.pk year=date.year month=date.month day=date.day %}">
+                                {{ date_name }}
+                            </a>
+                        </li>
                     {% endfor %}
-                </p>
+                </ul>
             </div>
         </div>
         <hr>

--- a/scheduler/views.py
+++ b/scheduler/views.py
@@ -59,7 +59,7 @@ class HelpDesk(LoginRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(HelpDesk, self).get_context_data(**kwargs)
         locations = context['locations'] = Location.objects.all()
-        the_dates = [{loc: loc.get_dates_of_needs()} for loc in locations]
+        the_dates = [{loc: loc.get_days_with_needs()} for loc in locations]
         context['need_dates_by_location'] = the_dates
         context['notifications'] = Notification.objects.all()
         return context


### PR DESCRIPTION
I slighlty cleaned up the helpdesk template and an associated method.

I was confused by what get_dates_of_needs does, and struck by the scary
approach to reverse the URL for the links. So quickly refactored with a
docstring and cleaner URL reversing.

Also removed glyphicons, and turned the list of days links into a HTML
list, giving us clean line breaks.

![image](https://cloud.githubusercontent.com/assets/509427/9999145/16f3da0c-6095-11e5-8dfd-20a21359d876.png)
