### PR TITLE
Fixed missing HTTP prefixes in URLs

### DIFF
--- a/blueprint/templates/blueprint_executor.html
+++ b/blueprint/templates/blueprint_executor.html
@@ -3,12 +3,12 @@
 <head lang="de">
     <meta charset="UTF-8">
     <title>{% block title %}Home{% endblock %}</title>
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
-    <script src="//code.jquery.com/jquery-1.10.2.js"></script>
-    <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
+    <script src="http://code.jquery.com/jquery-1.10.2.js"></script>
+    <script src="http://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
     <script src="/static/js/moment.js"></script>
     <link href="/static/bootstrap/dist/css/bootstrap.css?" rel="stylesheet" type="text/css">
-    <link href='//fonts.googleapis.com/css?family=Hind|Shadows+Into+Light' rel='stylesheet' type='text/css'>
+    <link href='http://fonts.googleapis.com/css?family=Hind|Shadows+Into+Light' rel='stylesheet' type='text/css'>
     <script>
 
         $(function () {

--- a/scheduler/static/bootstrap/docs/_includes/components/responsive-embed.html
+++ b/scheduler/static/bootstrap/docs/_includes/components/responsive-embed.html
@@ -6,7 +6,7 @@
   <p><strong>Pro-Tip!</strong> You don't need to include <code>frameborder="0"</code> in your <code>&lt;iframe&gt;</code>s as we override that for you.</p>
   <div class="bs-example" data-example-id="responsive-embed-16by9-iframe-youtube">
     <div class="embed-responsive embed-responsive-16by9">
-      <iframe class="embed-responsive-item" src="//www.youtube.com/embed/zpOULjyy-n8?rel=0" allowfullscreen></iframe>
+      <iframe class="embed-responsive-item" src="http://www.youtube.com/embed/zpOULjyy-n8?rel=0" allowfullscreen></iframe>
     </div>
   </div>
 {% highlight html %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -94,7 +94,7 @@
     </div>
 </div>
 {% block js %}
-    <script src="//code.jquery.com/jquery-1.10.2.min.js"
+    <script src="http://code.jquery.com/jquery-1.10.2.min.js"
             type="text/javascript"></script>
     <script src="/static/bootstrap/dist/js/bootstrap.min.js"
             type="text/javascript"></script>

--- a/templates/home.html
+++ b/templates/home.html
@@ -15,8 +15,7 @@
 
     {% include 'google_headers.html' %}
 
-    <link href='//fonts.googleapis.com/css?family=Hind|Shadows+Into+Light'
-          rel='stylesheet' type='text/css'>
+    <link href='http://fonts.googleapis.com/css?family=Hind|Shadows+Into+Light' rel='stylesheet' type='text/css'>
 </head>
 <body class="{% block body_class %} {% endblock %}">
 


### PR DESCRIPTION
There were several resource links broken, i.e. the HTTP prefix was missing. Some of the files do not belong to the actual code base.