### PR TITLE
Cherry Pick: Cancelation email threw error

### DIFF
--- a/scheduler/signals.py
+++ b/scheduler/signals.py
@@ -16,7 +16,7 @@ def send_email_notifications(sender, instance, **kwargs):
     add some error handling, some sane max recipient handling, tests, etc.
     """
     shift = instance
-    subject = u'Schicht am {} wurde abgesagt'.format()
+    subject = u'Schicht am {} wurde abgesagt'.format(shift.starting_time.strftime('%d.%m.%y'))
 
     message = render_to_string('shift_cancellation_notification.html', dict(shift=shift))
 


### PR DESCRIPTION
There was no date given for formatting email subject on cancelation
notification.