### PR TITLE
Fix showing working hours

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -80,7 +80,7 @@
                     {% get_volunteer_number %} Freiwillige sind bereits
                     registriert
                     {% if working_hours %}
-                        und haben {{ working_hours.value|intcomma }} Stunden
+                        und haben {{ working_hours.hours|intcomma }} Stunden
                         geholfen
                     {% endif %}
                 </h2>


### PR DESCRIPTION
Previous reintegrate-merge of develop had merge conflict in affected
line. Conflict was solved by overwriting necessary modification of
"working_hours.value" towards "working_hours.hours".