### PR TITLE
Fix for empty activation email

### DIFF
--- a/templates/registration/activation_email.html
+++ b/templates/registration/activation_email.html
@@ -1,0 +1,11 @@
+{% url 'registration_activate' as activation_key_url %}
+Hallo {{ user }},
+
+vielen Dank, dass Du helfen willst! Nur noch einen Schritt, dann kannst Du Dich für die Freiwilligendienste anmelden!
+
+Bitte klicke auf den folgenden Link um die Registrierung Deines Benutzerkontos abzuschließen.
+Dieser Link ist für {{ expiration_days }} Tage gültig.
+
+<href ="https://{{ site.domain }}{{activation_key_url}}?activation_key={{activation_key}}">https://{{ site.domain }}{{activation_key_url}}?activation_key={{activation_key}}</a>
+
+Dein Freiwilligen-Team zur Unterstützung der Geflüchteten


### PR DESCRIPTION
The HTML version of the template was empty. Only users with text-only email clients could see the activation email text.