### PR TITLE
Fix template syntax error in activate.html template

### DIFF
--- a/templates/registration/activate.html
+++ b/templates/registration/activate.html
@@ -12,7 +12,7 @@
     {% url 'auth_login' as auth_login_url %}
     {% if account %}
         {% trans "login" as login_link_title context "login link title in registration confirmation success text 'You may now %(login_link)s'" %}
-        {% blocktrans trimmed login_link='<a href="'|add:auth_login_url|add:'">'|add:login_link_title|add:'</a>'%}
+        {% blocktrans trimmed with login_link='<a href="'|add:auth_login_url|add:'">'|add:login_link_title|add:'</a>'%}
             Thanks {{ account }}, activation complete!
             You may now {{ login_link }} using the username and password you set at registration.
         {% endblocktrans %}


### PR DESCRIPTION
assigning template vars within blocktrans requires use of keyword 'with'