### PR TITLE
Documentation and tweaks for behave tests and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ env: DJANGO_SETTINGS_MODULE=volunteer_planner.settings.tests
 install: "pip install -r requirements/dev.txt"
 
 # Fire up a webserver for Selenium
-before_script: gunicorn -D volunteer_planner.wsgi_behave
+before_script:
+- ./manage.py migrate
+- gunicorn -D volunteer_planner.wsgi_behave
 
 script:
 # Python tests (mostly unit tests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,22 @@
 language: python
+
 python: "2.7"
+
+env: DJANGO_SETTINGS_MODULE=volunteer_planner.settings.tests
+
 install: "pip install -r requirements/dev.txt"
-env: DJANGO_SETTINGS_MODULE=volunteer_planner.settings.local
+
+# Fire up a webserver for Selenium
 before_script: gunicorn -D volunteer_planner.wsgi_behave
+
 script:
+# Python tests (mostly unit tests)
 - py.test --create-db tests/
+
+# Our behave tests (using Selenium)
 - behave tests/_behave
+
+# Disable Travis rather annoying email notifications. Talk to Maik
+# if you want them enabled.
 notifications:
   email: false

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/blueprint/tests.py
+++ b/blueprint/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/common/tests.py
+++ b/common/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/non_logged_in_area/tests.py
+++ b/non_logged_in_area/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/notifications/tests.py
+++ b/notifications/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/places/tests.py
+++ b/places/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/scheduler/tests.py
+++ b/scheduler/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/shiftmailer/tests.py
+++ b/shiftmailer/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/tests/_behave/environment.py
+++ b/tests/_behave/environment.py
@@ -1,9 +1,20 @@
 from selenium import webdriver
 
+# This file is picked up by behave, and is where we tie behave and Selenium
+# together.
+
 
 def before_all(context):
+    """
+    Steps to be executed before behave features are run.
+    Serves to fire up PhantomJS.
+    """
     context.browser = webdriver.PhantomJS()
 
 
 def after_all(context):
+    """
+    Steps to execute after all features have run.
+    Serves to stop PhantomJS again.
+    """
     context.browser.quit()

--- a/volunteer_planner/settings/tests.py
+++ b/volunteer_planner/settings/tests.py
@@ -2,8 +2,10 @@ from .base import *
 
 # Settings for running our tests
 
-# TODO: Should run with DEBUG = False
-DEBUG = True
+DEBUG = False
+
+# Needed for letting Selenium access our server.
+ALLOWED_HOSTS = ['localhost']
 
 # TODO: Should run against MySQL
 DATABASES = {

--- a/volunteer_planner/settings/tests.py
+++ b/volunteer_planner/settings/tests.py
@@ -1,0 +1,17 @@
+from .base import *
+
+# Settings for running our tests
+
+# TODO: Should run with DEBUG = False
+DEBUG = True
+
+# TODO: Should run against MySQL
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        # Intentionally out of repository so that git clean doesn't delete the file.
+        'NAME': 'db.sqlite3',
+    }
+}
+
+SECRET_KEY = 'Kitten like fish'

--- a/volunteer_planner/wsgi.py
+++ b/volunteer_planner/wsgi.py
@@ -1,10 +1,5 @@
 """
-WSGI config for boilerplate project.
-
-It exposes the WSGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-
+WSGI config for production setup.
 """
 
 import os

--- a/volunteer_planner/wsgi_behave.py
+++ b/volunteer_planner/wsgi_behave.py
@@ -1,13 +1,10 @@
 """
 WSGI config for running selenium tests only.
 
-Main difference is that it uses the lovely WhiteNoise to serve our static files.
+Sole difference is that it uses the lovely WhiteNoise to serve our static files.
 """
 
-import os
 from django.core.wsgi import get_wsgi_application
 from whitenoise.django import DjangoWhiteNoise
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "volunteer_planner.settings.local")
 
 application = DjangoWhiteNoise(get_wsgi_application())


### PR DESCRIPTION
Experience tells me it makes sense to have dedicated tests settings.
That way, we won't run against the debug toolbar, can migrate to testing
against Debug=False, can use MD5 password hashers to get some
low-hanging performance improvements...