### PR TITLE
introduced fix that forces PhantomJS browser to request English locale

### DIFF
--- a/tests/_behave/environment.py
+++ b/tests/_behave/environment.py
@@ -9,6 +9,7 @@ def before_all(context):
     Steps to be executed before behave features are run.
     Serves to fire up PhantomJS.
     """
+    webdriver.DesiredCapabilities.PHANTOMJS['phantomjs.page.customHeaders.Accept-Language'] = 'en-US'
     context.browser = webdriver.PhantomJS()
 
 


### PR DESCRIPTION
On my local machine, Maik's smoke test did not pass.

Apparently, the browser served German content while the tests checked for certain English words in the response. 

I introduced a fix (found here: http://stackoverflow.com/a/17862456) that sets the request header 'Accept-Language' to 'en-US'. 

Now, the smoke test no longer fails on my machine. 

Please verify that this fix works for you, too :-) 