### PR TITLE
161 - monkey patch email uniqueness

### DIFF
--- a/accounts/__init__.py
+++ b/accounts/__init__.py
@@ -1,0 +1,4 @@
+from django.contrib.auth.models import User
+
+# monkey patching to make emails unique for users
+User._meta.get_field_by_name('email')[0]._unique = True


### PR DESCRIPTION
#161 should be fixed

this is a rather dirty patch taken from
https://stackoverflow.com/questions/2278855/making-email-field-unique-with-django-user-admin

this has the advantage that old users do not need to be "merged", but new accounts can't register with the same email adress.
Cleaner would be an own UserModel with said disadvantages.