### PR TITLE
Fix schedule template apply view date picker date format

### DIFF
--- a/scheduletemplates/templates/admin/scheduletemplates/apply_template.html
+++ b/scheduletemplates/templates/admin/scheduletemplates/apply_template.html
@@ -21,7 +21,7 @@
                 constrainInput: false,
                 showWeek: true,
                 weekHeader: "W",
-                dateFormat: "{{ apply_form.js_date_format|default:'apply_form' }}"
+                dateFormat: "{{ apply_form.js_date_format|default:'m.d.yy' }}"
             });
         });
     </script>


### PR DESCRIPTION
The default value was not an actual date format but the forms' variable name instead (dunno, why).