### PR TITLE
Add 'request_site' template tag

### DIFF
--- a/common/templatetags/site.py
+++ b/common/templatetags/site.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+
+# coding: utf-8
+
+from django import template
+
+from django.contrib.sites.shortcuts import get_current_site
+
+register = template.Library()
+
+
+@register.assignment_tag
+def request_site(request):
+    return get_current_site(request_site)

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-{% load staticfiles %}
+{% load staticfiles site %}
+{% request_site request as site %}
 
 <html{% block html_attributes %}{% endblock %}>
 <head>
@@ -7,7 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>{% block title %}volunteer-planner.org{% endblock %}</title>
+    <title>{% block title %}{{ site.domain }}{% endblock %}</title>
 
     {% include "google_headers.html" %}
 

--- a/templates/partials/navigation_bar.html
+++ b/templates/partials/navigation_bar.html
@@ -1,4 +1,6 @@
-{% load i18n %}
+{% load i18n site %}
+{% request_site request as site %}
+
 {# Bootstrap 3 nav bar, only shown in logged-in areas #}
 
 <nav class="navbar navbar-default navbar-fixed-top">
@@ -11,7 +13,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="{% url 'helpdesk' %}">volunteer-planner.org</a>
+            <a class="navbar-brand" href="{% url 'helpdesk' %}">{{ site.domain }}</a>
         </div>
 
         <div id="navbar" class="collapse navbar-collapse">


### PR DESCRIPTION
Gets the current requests' site (domain) in templates.

Example usage in templates (request is supposed to be a variable containing the current request):

{% load site %}
{% request_site request as site %}

{{ site.domain }}